### PR TITLE
fixed a errant equal sign

### DIFF
--- a/infra/deploy/main.tf
+++ b/infra/deploy/main.tf
@@ -29,7 +29,7 @@ provider "aws" {
 }
 
 locals {
-  prefix = "${var.prefix}=${terraform.workspace}"
+  prefix = "${var.prefix}-${terraform.workspace}"
 }
 
 data "aws_region" "current" {}


### PR DESCRIPTION
An errant equal sign in main.tf caused the character to be interoplated into the name of an AWS resource. That AWS resource rejected the equal sign, but can accept dashes.