### PR TITLE
expanded permissions and corrected EOL postgres version

### DIFF
--- a/infra/deploy/database.tf
+++ b/infra/deploy/database.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "main" {
   allocated_storage          = 20    # in gb
   storage_type               = "io1" # "gp2" for simplest
   engine                     = "postgres"
-  engine_version             = "15.3"
+  engine_version             = "15.13"
   auto_minor_version_upgrade = true
   instance_class             = "db.t4g.micro" # "db.t4g.micro" for simplest
   iops                       = 500            # 50x20 = 1000. 1000 would be the max here

--- a/infra/setup/iam.tf
+++ b/infra/setup/iam.tf
@@ -169,7 +169,8 @@ data "aws_iam_policy_document" "rds" {
       "rds:CreateDBInstance",
       "rds:DeleteDBInstance",
       "rds:ListTagsForResource",
-      "rds:ModifyDBInstance"
+      "rds:ModifyDBInstance",
+      "rds:AddTagsToResource"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
The class documentation needed updates.

First, posgres 15.3 is EOL and it would not deploy.

Second, additional AIM permissions in RDS:* were needed to tag resources.