### PR TITLE
set up user required more permissions.

### DIFF
--- a/infra/setup/iam.tf
+++ b/infra/setup/iam.tf
@@ -246,7 +246,9 @@ data "aws_iam_policy_document" "iam" {
       "iam:AttachRolePolicy",
       "iam:TagRole",
       "iam:TagPolicy",
-      "iam:PassRole"
+      "iam:PassRole",
+      "iam:UpdateAssumeRolePolicy",
+      "iam:UpdateRoleDescription"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
The set up user requires at least two more permission action to get this running.