### PR TITLE
fixed error again.

### DIFF
--- a/infra/deploy/ecs.tf
+++ b/infra/deploy/ecs.tf
@@ -188,8 +188,8 @@ resource "aws_security_group" "ecs_service" {
     from_port = 8000
     to_port   = 8000
     protocol  = "tcp"
-    cidr_blocks = [
-      aws_security_group.loadbalancer.cidr_block
+    security_groups = [
+      aws_security_group.loadbalancer.id
     ]
   }
 }


### PR DESCRIPTION
So it turns out that you must reference a variable called security group if you are going to input an array of security groups.